### PR TITLE
o.c.iter.opibuilder.patch: added number_alarms property

### DIFF
--- a/plugins/org.csstudio.iter.opibuilder.patch/fragment.xml
+++ b/plugins/org.csstudio.iter.opibuilder.patch/fragment.xml
@@ -84,7 +84,7 @@
          </visibility>
          <menu
                id="org.csstudio.opibuilder.beastSubMenu"
-               label="BEAST Alarm"
+               label="Latched Alarm"
                path="additions">
             <separator
                   name="beastsub1">

--- a/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
+++ b/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
@@ -24,8 +24,10 @@ import org.csstudio.opibuilder.preferences.BeastPreferencesHelper;
 import org.csstudio.opibuilder.preferences.PreferencesHelper;
 import org.csstudio.opibuilder.properties.AbstractWidgetProperty;
 import org.csstudio.opibuilder.properties.IWidgetPropertyChangeHandler;
+import org.csstudio.opibuilder.properties.IntegerProperty;
 import org.csstudio.opibuilder.properties.PVValueProperty;
 import org.csstudio.opibuilder.properties.StringProperty;
+import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 import org.csstudio.opibuilder.util.AlarmRepresentationScheme;
 import org.csstudio.opibuilder.util.BOYPVFactory;
 import org.csstudio.opibuilder.util.BeastAlarmInfo;
@@ -878,6 +880,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
     private boolean isBeastAlarm = false;
     private boolean isBeastAlarmNode = false; // is this an Alarm Node instead of a PV ?
     private final BeastAlarmInfo beastInfo = new BeastAlarmInfo();
+    private static final String PROP_NUMBER_ALARMS = "number_alarms";//$NON-NLS-1$
 
     /**
      * Returns whether BEAST Alarm functionality is enabled and available (listener connected to the BeastDataSource).
@@ -1082,6 +1085,12 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
             beastInfo.setAlarmPVsCount(0);
             return;
         }
+        AbstractWidgetModel model = (AbstractWidgetModel)getWidgetModel(); 
+        if (model.getProperty(PROP_NUMBER_ALARMS) == null) {
+            // add a property for the number of active Beast alarms of Node "PVs"
+            model.addProperty(new IntegerProperty(PROP_NUMBER_ALARMS, "Number of Beast alarms", WidgetPropertyCategory.Basic, 0));
+            model.setPropertyVisible(PROP_NUMBER_ALARMS, false);
+        }
 
         log.fine("Starting BeastAlarmListener for channel " + alarmPVName);
         beastInfo.setBeastChannelName(alarmPVName);
@@ -1174,16 +1183,25 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                             List<String> data = (List<String>) table.getColumnData(1);
 
                             AlarmSeverity beastSeverity;
+                            int alarmsCount = 0;
                             synchronized (beast) {
                                 beast.setLatchedSeverity(BeastAlarmSeverityLevel.parse(data.get(latchedSeverityIdx)));
                                 beast.setCurrentSeverity(BeastAlarmSeverityLevel.parse(data.get(currentSeverityIdx)));
                                 beastSeverity = beast.getCurrentAlarmSeverity();
-                                if (alarmsCountIdx != -1)
-                                    beast.setAlarmPVsCount(Integer.parseInt(data.get(alarmsCountIdx)));
+                                if (alarmsCountIdx != -1) {
+                                    alarmsCount = Integer.parseInt(data.get(alarmsCountIdx));
+                                    beast.setAlarmPVsCount(alarmsCount);
+                                }
                             }
 
                             if (pvWidget.getAlarmSeverity() != beastSeverity) {
                                 pvWidget.setAlarmSeverity(beastSeverity);
+                            }
+                            
+                            // if this is an Alarm Node PV, update the tooltip
+                            if (pvWidget.isBeastAlarmNode()) {
+                                AbstractWidgetModel model = (AbstractWidgetModel) pvWidget.getWidgetModel();
+                                model.setPropertyValue(PROP_NUMBER_ALARMS, alarmsCount);
                             }
 
                             pvWidget.processBeastAlarmState();

--- a/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
+++ b/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
@@ -1198,7 +1198,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                                 pvWidget.setAlarmSeverity(beastSeverity);
                             }
                             
-                            // if this is an Alarm Node PV, update the tooltip
+                            // if this is an Alarm Node PV, update the number_alarms property
                             if (pvWidget.isBeastAlarmNode()) {
                                 AbstractWidgetModel model = (AbstractWidgetModel) pvWidget.getWidgetModel();
                                 model.setPropertyValue(PROP_NUMBER_ALARMS, alarmsCount);

--- a/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/util/BeastAlarmInfo.java
+++ b/plugins/org.csstudio.iter.opibuilder.patch/src/org/csstudio/opibuilder/util/BeastAlarmInfo.java
@@ -66,7 +66,7 @@ public final class BeastAlarmInfo {
      * @return the Latched Severity of the BEAST alarm, see {@link BeastAlarmSeverityLevel}.
      */
     public BeastAlarmSeverityLevel getLatchedSeverity() {
-        return currentSeverity;
+        return latchedSeverity;
     }
 
     /**


### PR DESCRIPTION
createBeastAlarmListener now adds a number_alarms property, which is set by the BeastDataSource listener (to be able to use $number_alarms macro in OPIs)
